### PR TITLE
fix: the hmac secret used for signing api requests c... in...

### DIFF
--- a/generateTimetable.js
+++ b/generateTimetable.js
@@ -16,8 +16,8 @@ const deviceId = "92542A7E-B31D-461F-8B1C-15215824E3F9"
 const deviceModel = "MacBook Air M4 24GB RAM 512GB ROM"
 const username = process.env.TARUMT_USERNAME;
 const password = process.env.TARUMT_PASSWORD;
-// APP_SECRET is set in GitHub Actions workflow, fallback for local development
-const APP_SECRET = process.env.APP_SECRET || "3f8a7c12d9e54b88b6a2f4d915c3e7a1";
+// APP_SECRET must be set in environment variables (GitHub Actions workflow or local .env)
+const APP_SECRET = process.env.APP_SECRET;
 
 /**
  * Create HMAC-SHA-256 signature


### PR DESCRIPTION
## Summary
Fix high severity security issue in `generateTimetable.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `generateTimetable.js:18` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The HMAC secret used for signing API requests contains a hardcoded fallback value exposed in source code. While the code attempts to load from environment variables, the default secret '3f8a7c12d9e54b88b6a2f4d915c3e7a1' is committed to the repository and used to create HMAC-SHA-256 signatures for all API requests to the TARUMT service.

## Evidence

**Exploitation scenario**: An attacker clones the repository and extracts the hardcoded secret from line 18.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `generateTimetable.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
